### PR TITLE
feat: add replyMsgId parameter support for API quota reduction

### DIFF
--- a/src/main/java/snw/jkook/entity/User.java
+++ b/src/main/java/snw/jkook/entity/User.java
@@ -156,6 +156,30 @@ public interface User extends Nameable, AvatarHolder, CommandSender {
     String sendPrivateMessage(BaseComponent component, PrivateMessage quote);
 
     /**
+     * Send a component to this user.
+     *
+     * @param message    The message content
+     * @param quote      If this parameter is passed in, the incoming message
+     *                   will be considered a reply to the message corresponding to this parameter
+     * @param replyMsgId The msg_id of a message sent by the user within 5 minutes.
+     *                   If this is the first reply from the bot, the daily quota consumption will be reduced.
+     * @return The Message ID
+     */
+    String sendPrivateMessage(String message, @Nullable PrivateMessage quote, @Nullable String replyMsgId);
+
+    /**
+     * Send a component to this user.
+     *
+     * @param component  The component to send
+     * @param quote      If this parameter is passed in, the incoming message
+     *                   will be considered a reply to the message corresponding to this parameter
+     * @param replyMsgId The msg_id of a message sent by the user within 5 minutes.
+     *                   If this is the first reply from the bot, the daily quota consumption will be reduced.
+     * @return The Message ID
+     */
+    String sendPrivateMessage(BaseComponent component, @Nullable PrivateMessage quote, @Nullable String replyMsgId);
+
+    /**
      * Get the voice channel which this user joined.<br>
      *
      * Why this method return a {@code PageIterator<Collection<VoiceChannel>>}?<br>

--- a/src/main/java/snw/jkook/entity/channel/NonCategoryChannel.java
+++ b/src/main/java/snw/jkook/entity/channel/NonCategoryChannel.java
@@ -109,4 +109,32 @@ public interface NonCategoryChannel extends Channel, InviteHolder {
      * @param ms The time in <b>milliseconds</b>
      */
     void setChatLimitTime(int ms);
+
+    /**
+     * Send a message to this channel.
+     *
+     * @param message    The message to send
+     * @param quote      If this parameter is passed in, the incoming message
+     *                   will be considered a reply to the message corresponding to this parameter
+     * @param tempTarget If you pass this parameter,
+     *                   only the user to whom it corresponds can see the incoming message
+     * @param replyMsgId The msg_id of a message sent by the user within 5 minutes in the same channel.
+     *                   If this is the first reply from the bot, the daily quota consumption will be reduced.
+     * @return Message ID
+     */
+    String sendComponent(String message, @Nullable ChannelMessage quote, @Nullable User tempTarget, @Nullable String replyMsgId);
+
+    /**
+     * Send a message to this channel.
+     *
+     * @param component  The message to send
+     * @param quote      If this parameter is passed in, the incoming message
+     *                   will be considered a reply to the message corresponding to this parameter
+     * @param tempTarget If you pass this parameter,
+     *                   only the user to whom it corresponds can see the incoming message
+     * @param replyMsgId The msg_id of a message sent by the user within 5 minutes in the same channel.
+     *                   If this is the first reply from the bot, the daily quota consumption will be reduced.
+     * @return Message ID
+     */
+    String sendComponent(BaseComponent component, @Nullable ChannelMessage quote, @Nullable User tempTarget, @Nullable String replyMsgId);
 }

--- a/src/main/java/snw/jkook/message/ChannelMessage.java
+++ b/src/main/java/snw/jkook/message/ChannelMessage.java
@@ -1,5 +1,6 @@
 package snw.jkook.message;
 
+import org.jetbrains.annotations.Nullable;
 import snw.jkook.Permission;
 import snw.jkook.entity.CustomEmoji;
 import snw.jkook.entity.User;
@@ -75,6 +76,28 @@ public interface ChannelMessage extends Message {
      * @param content The new content
      */
     void setComponentTemp(User user, String content);
+
+    /**
+     * Set the component that stored by this message. <p>
+     * Only support messages that contains {@link MarkdownComponent} or Card (both {@link CardComponent} and {@link MultipleCardComponent}) <b>now</b>.
+     *
+     * @param component  The component
+     * @param quote      The msgId to quote. Pass empty string to remove quote, pass null to keep unchanged.
+     * @param replyMsgId The msg_id of a message sent by the user within 5 minutes in the same channel.
+     *                   If this is the first reply from the bot, the daily quota consumption will be reduced.
+     */
+    void setComponent(BaseComponent component, @Nullable String quote, @Nullable String replyMsgId);
+
+    /**
+     * Set the content that stored by this message. <br>
+     * This method just constructs the {@link MarkdownComponent} with provided content and pass it to {@link #setComponent(BaseComponent, String, String)}.
+     *
+     * @param content    The new content
+     * @param quote      The msgId to quote. Pass empty string to remove quote, pass null to keep unchanged.
+     * @param replyMsgId The msg_id of a message sent by the user within 5 minutes in the same channel.
+     *                   If this is the first reply from the bot, the daily quota consumption will be reduced.
+     */
+    void setComponent(String content, @Nullable String quote, @Nullable String replyMsgId);
 
     /**
      * Remove a reaction that added by the specified user.

--- a/src/main/java/snw/jkook/message/PrivateMessage.java
+++ b/src/main/java/snw/jkook/message/PrivateMessage.java
@@ -16,8 +16,31 @@
 
 package snw.jkook.message;
 
+import org.jetbrains.annotations.Nullable;
+import snw.jkook.message.component.BaseComponent;
+
 /**
  * Represents a private message.
  */
 public interface PrivateMessage extends Message {
+
+    /**
+     * Set the component that stored by this message.
+     *
+     * @param component  The component
+     * @param quote      The msgId to quote. Pass empty string to remove quote, pass null to keep unchanged.
+     * @param replyMsgId The msg_id of a message sent by the user within 5 minutes.
+     *                   If this is the first reply from the bot, the daily quota consumption will be reduced.
+     */
+    void setComponent(BaseComponent component, @Nullable String quote, @Nullable String replyMsgId);
+
+    /**
+     * Set the content that stored by this message.
+     *
+     * @param content    The new content
+     * @param quote      The msgId to quote. Pass empty string to remove quote, pass null to keep unchanged.
+     * @param replyMsgId The msg_id of a message sent by the user within 5 minutes.
+     *                   If this is the first reply from the bot, the daily quota consumption will be reduced.
+     */
+    void setComponent(String content, @Nullable String quote, @Nullable String replyMsgId);
 }


### PR DESCRIPTION
- NonCategoryChannel: add sendComponent with replyMsgId
- ChannelMessage: add setComponent with quote and replyMsgId
- User: add sendPrivateMessage with replyMsgId
- PrivateMessage: add setComponent with quote and replyMsgId